### PR TITLE
Fix some bug in smpl_transfer

### DIFF
--- a/scripts/data_processors/smpl/smpl_transfer.py
+++ b/scripts/data_processors/smpl/smpl_transfer.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
                 result_dict["cam_t"] = cam_t
                 result_dict["scaled_focal_length"] = foc_len
                 if args.figure_transfer:
-                    result_dict["smpls"] = smpl_outs["smpls"]
+                    result_dict["smpls"] = smpl_outs
                 if args.view_transfer:
                     scaled_focal_length = reference_dict["scaled_focal_length"]
                     result_dict["cam_t"] = reference_dict["cam_t"]

--- a/scripts/data_processors/smpl/smpl_transfer.py
+++ b/scripts/data_processors/smpl/smpl_transfer.py
@@ -110,9 +110,11 @@ if __name__ == "__main__":
             ):
                 img_fn, _ = os.path.splitext(os.path.basename(file_path))
                 result_dict = {key: value for key, value in result_dict_first.items()}
-                result_dict["smpls"] = smpl_outs
+                result_dict["smpls"] = reference_dict["smpls"]
                 result_dict["cam_t"] = cam_t
                 result_dict["scaled_focal_length"] = foc_len
+                if args.figure_transfer:
+                    result_dict["smpls"] = smpl_outs["smpls"]
                 if args.view_transfer:
                     scaled_focal_length = reference_dict["scaled_focal_length"]
                     result_dict["cam_t"] = reference_dict["cam_t"]

--- a/scripts/data_processors/smpl/smpl_transfer.py
+++ b/scripts/data_processors/smpl/smpl_transfer.py
@@ -110,11 +110,11 @@ if __name__ == "__main__":
             ):
                 img_fn, _ = os.path.splitext(os.path.basename(file_path))
                 result_dict = {key: value for key, value in result_dict_first.items()}
-                result_dict["smpls"] = reference_dict["smpls"]
+                result_dict["smpls"] = smpl_outs
                 result_dict["cam_t"] = cam_t
                 result_dict["scaled_focal_length"] = foc_len
-                if args.figure_transfer:
-                    result_dict["smpls"] = smpl_outs
+                if not args.figure_transfer:
+                    result_dict["smpls"]["betas"] = reference_dict["smpls"]["betas"]
                 if args.view_transfer:
                     scaled_focal_length = reference_dict["scaled_focal_length"]
                     result_dict["cam_t"] = reference_dict["cam_t"]


### PR DESCRIPTION
I found that adjusting the figure_transfer parameter during the Transfer SMPL step of data_process will not cause the adjustment of the generated image on the human body size. I tracked down the missing handling of this parameter in script.data_processors.smpl.smpl_transfer.py and fixed the bug.