### PR TITLE
feat: Chunk guidance encoding to reduce GRAM usage

### DIFF
--- a/configs/inference/inference.yaml
+++ b/configs/inference/inference.yaml
@@ -5,6 +5,7 @@ data:
   ref_image_path: 'example_data/ref_images/ref-02.png'  # reference image path
   guidance_data_folder: 'example_data/motions/motion-02'  # corresponding motion sequence folder
   frame_range: [0, 100]  # [Optional] specify a frame range: [min_frame_idx, max_frame_idx] to select a clip from a motion sequence  
+  # guidance_process_size: 100  # [Optional] To reduce GRAM usage, the guidance tensor is divided for encoding and then concatenated
 seed: 42
 
 base_model_path: 'pretrained_models/stable-diffusion-v1-5'

--- a/inference.py
+++ b/inference.py
@@ -135,6 +135,7 @@ def inference(
         denoising_unet=denoising_unet,
         **guidance_encoder_group,
         scheduler=scheduler,
+        guidance_process_size=cfg.data.get("guidance_process_size", None)
     )
     pipeline = pipeline.to(device, dtype)
 


### PR DESCRIPTION
Thank you for sharing nice research!

While using inference code, I noticed that GRAM usage was significantly affected by the frame range ([0, 100], [0, 500], etc).
On my GPU, using around 500 frames caused an OOM error.

During this investigation, I observed that GRAM usage was heavily influenced by the guidance encoder. By dividing this operation into chunks and concatenating the results, I was able to reduce GRAM usage.

Disclaimer:
  1. I haven't fully reviewed the code yet, so I assume that guidance encoding is not affected by the time dimension.
  2. For measurement purposes, I call torch.cuda.empty_cache() after encoding the guidance but before the diffusion process.

Measurement:
![image](https://github.com/fudan-generative-vision/champ/assets/129421/11a18ee5-4f0c-4e06-b6e5-7fb9998c49d1)
